### PR TITLE
UX batch: onboarding calculator, default foods, theme toggle, bulk default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,16 @@ pnpm gen:api     # regenerate frontend/src/api/types.gen.ts from the backend's O
 3. **Regenerate `types.gen.ts` after any backend schema change** (`pnpm gen:api`
    from `frontend/`, backend venv synced first). A clean tree should produce
    zero diff — if it doesn't, the frontend types are stale.
-4. **Dark mode is `prefers-color-scheme` only.** No manual toggle, no `.dark`
-   class switching — media-strategy dark mode is a locked decision, not an
-   oversight.
+4. **Theme is a three-way toggle — light / dark / system, defaulting to
+   system.** Class-strategy with a system fallback (`frontend/src/lib/theme.ts`):
+   a `data-theme` attribute on `<html>` for an explicit light/dark choice,
+   *absent* for system, where the `prefers-color-scheme` media query drives the
+   flip. Dark tokens live under **both** `[data-theme="dark"]` and that media
+   query scoped to `:root:not([data-theme])`; light under
+   `:root, [data-theme="light"]` (`frontend/src/index.css`). No third-party theme
+   library (no `next-themes`). This deliberately **reverses** the earlier
+   media-only, no-toggle decision — the product owner changed it after living
+   with the app; do not "fix" the toggle away.
 5. **Metric only.** kg, grams/pieces, kcal. No lbs, no unit conversion layer.
 6. **The Out of Scope list in `FEATURE_PARITY.md` is binding**: no auth, no
    per-cat meals-per-day, no offline/sync, no notifications/photos, no

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -19,7 +19,7 @@ Design for a handful of cats (~3), not N: cat selection is a single row of butto
 - **Time**: store true UTC everywhere. A single household timezone in backend settings drives "today", day bucketing, and report boundaries. The frontend never sends a timezone.
 - **Units**: metric only — kg for cats, grams/pieces for food, kcal for energy. No lbs support.
 - **Mobile**: installable PWA (manifest + icons), online-only, no offline queue. **Target device: iPhone 13 mini (375 pt-wide viewport)** — every Dashboard interaction must be easy and fast at that size, one-handed. The Dashboard is mobile-first; History and Settings are desktop-first (they must render sanely on the phone, but are designed for and mostly used from desktop).
-- **Theming**: dark/light follows the system preference (`prefers-color-scheme`) automatically on iOS and desktop. No manual theme toggle.
+- **Theming**: three-way light / dark / system toggle, defaulting to system. System follows `prefers-color-scheme` automatically on iOS and desktop; light and dark are explicit overrides persisted per device. Class-strategy with a system fallback, no third-party theme library. (This reverses the original "system preference only, no toggle" decision — changed by the product owner after living with the app.)
 
 ## Core Model
 
@@ -84,6 +84,7 @@ Design for a handful of cats (~3), not N: cat selection is a single row of butto
 
 - Suggest a daily target from veterinary formulas: RER = 70 × (kg)^0.75, applied to **goal weight** with a weight-loss factor (≈0.8 × RER) when a goal is set, or maintenance factor on current weight when not.
 - Always a suggestion — the stored target is editable and can ignore the calculator entirely.
+- Available two ways: for an existing cat (from its stored goal/current weight), and **at cat creation** — once a weight is entered in the Add-cat form the suggestion is computed from that entered weight (and optional goal weight, before the cat exists) and can prefill the target. Same endpoint (`target-suggestion`), which accepts either a `cat_id` or an explicit `weight_kg`.
 
 ### Weight Tracking
 
@@ -111,8 +112,9 @@ Design for a handful of cats (~3), not N: cat selection is a single row of butto
 
 ### Settings
 
-- Manage cats (including goal weight and default foods).
-- Manage the food library (all three types, either calorie basis).
+- Manage cats (including goal weight and default foods). Default wet/dry foods are optional and can be chosen **at cat creation**, not only when editing (an empty library shows an "add foods in Settings first" hint and never blocks creating the cat).
+- Manage the food library (all three types, either calorie basis). When adding or editing a **wet or dry** food, an optional "set as default for all cats" affordance points every cat's matching default at that food in one action (never offered for treats; a success message reports how many cats were updated). Existing meal snapshots are untouched.
+- Theme toggle (light / dark / system) lives in the household card.
 - Portion suggestion settings and household timezone.
 
 ## Pages
@@ -149,7 +151,7 @@ Design for a handful of cats (~3), not N: cat selection is a single row of butto
 
 ## Parity Chrome (keep)
 
-- Dark mode via system preference auto-detect (no toggle — see Theming decision)
+- Dark mode with a three-way light / dark / system toggle, defaulting to system preference auto-detect (see Theming decision)
 - Seed data for development
 - Single clean CI workflow: backend (ruff, mypy, pytest) + frontend (tsc, vitest, build) + docker image build. Replaces the old node.js/CodeQL/Codacy/docker workflows.
 

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -19,7 +19,7 @@ Design for a handful of cats (~3), not N: cat selection is a single row of butto
 - **Time**: store true UTC everywhere. A single household timezone in backend settings drives "today", day bucketing, and report boundaries. The frontend never sends a timezone.
 - **Units**: metric only — kg for cats, grams/pieces for food, kcal for energy. No lbs support.
 - **Mobile**: installable PWA (manifest + icons), online-only, no offline queue. **Target device: iPhone 13 mini (375 pt-wide viewport)** — every Dashboard interaction must be easy and fast at that size, one-handed. The Dashboard is mobile-first; History and Settings are desktop-first (they must render sanely on the phone, but are designed for and mostly used from desktop).
-- **Theming**: three-way light / dark / system toggle, defaulting to system. System follows `prefers-color-scheme` automatically on iOS and desktop; light and dark are explicit overrides persisted per device. Class-strategy with a system fallback, no third-party theme library. (This reverses the original "system preference only, no toggle" decision — changed by the product owner after living with the app.)
+- **Theming**: three-way light / dark / system toggle, defaulting to system. System follows `prefers-color-scheme` automatically on iOS and desktop; light and dark are explicit overrides persisted per device via a `data-theme` attribute on `<html>`, no third-party theme library. (This reverses the original "system preference only, no toggle" decision — changed by the product owner after living with the app.)
 
 ## Core Model
 

--- a/backend/app/routers/cats.py
+++ b/backend/app/routers/cats.py
@@ -16,6 +16,7 @@ from sqlalchemy import func, select
 from app.config import get_settings
 from app.db import SessionDep
 from app.models import Cat, Food, FoodType, Meal, WeightEntry
+from app.routers.foods import ensure_food_not_archived
 from app.schemas import (
     CatCreate,
     CatResponse,
@@ -36,10 +37,7 @@ def _validate_default_food(session: Session, food_id: int, expected_type: FoodTy
     food = session.get(Food, food_id)
     if food is None:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Food {food_id} does not exist")
-    if food.archived_at is not None:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, f"Food {food_id} is archived and cannot be a default"
-        )
+    ensure_food_not_archived(food)
     if food.type is not expected_type:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,

--- a/backend/app/routers/foods.py
+++ b/backend/app/routers/foods.py
@@ -14,8 +14,14 @@ from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import func, select
 
 from app.db import SessionDep
-from app.models import Cat, Food, Meal
-from app.schemas import FoodCreate, FoodDeleteResult, FoodResponse, FoodUpdate
+from app.models import Cat, Food, FoodType, Meal
+from app.schemas import (
+    FoodCreate,
+    FoodDeleteResult,
+    FoodMutationResult,
+    FoodResponse,
+    FoodUpdate,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -28,6 +34,35 @@ def _get_food_or_404(session: Session, food_id: int) -> Food:
     if food is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Food {food_id} not found")
     return food
+
+
+def _apply_default_for_all_cats(session: Session, food: Food) -> int:
+    """Point every cat's matching (wet/dry) default at ``food``; return the count.
+
+    Only valid for a non-archived WET/DRY food — mirrors the per-cat default
+    validation (``cats._validate_default_food``); a TREAT or archived food → 400.
+    Existing meals are untouched: their calories come from the snapshot taken at
+    log time, so re-pointing a default never rewrites history.
+    """
+
+    if food.type is FoodType.TREAT:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "A treat cannot be set as a default wet/dry food",
+        )
+    if food.archived_at is not None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Food {food.id} is archived and cannot be a default",
+        )
+
+    cats = session.scalars(select(Cat)).all()
+    for cat in cats:
+        if food.type is FoodType.WET:
+            cat.default_wet_food_id = food.id
+        else:
+            cat.default_dry_food_id = food.id
+    return len(cats)
 
 
 def _clear_from_defaults(session: Session, food_id: int) -> list[int]:
@@ -59,7 +94,7 @@ def list_foods(
 
 
 @router.post("/foods", status_code=status.HTTP_201_CREATED)
-def create_food(payload: FoodCreate, session: SessionDep) -> FoodResponse:
+def create_food(payload: FoodCreate, session: SessionDep) -> FoodMutationResult:
     food = Food(
         name=payload.name,
         type=payload.type,
@@ -67,13 +102,21 @@ def create_food(payload: FoodCreate, session: SessionDep) -> FoodResponse:
         kcal_per_basis=payload.kcal_per_basis,
     )
     session.add(food)
+    session.flush()  # assign food.id before it can be pointed at from cat defaults
+
+    defaulted = (
+        _apply_default_for_all_cats(session, food) if payload.set_default_for_all_cats else 0
+    )
+
     session.commit()
     session.refresh(food)
-    return FoodResponse.model_validate(food)
+    return FoodMutationResult(
+        food=FoodResponse.model_validate(food), defaulted_for_cat_count=defaulted
+    )
 
 
 @router.patch("/foods/{food_id}")
-def update_food(food_id: int, payload: FoodUpdate, session: SessionDep) -> FoodResponse:
+def update_food(food_id: int, payload: FoodUpdate, session: SessionDep) -> FoodMutationResult:
     food = _get_food_or_404(session, food_id)
 
     if payload.type is not None and payload.type is not food.type:
@@ -82,13 +125,19 @@ def update_food(food_id: int, payload: FoodUpdate, session: SessionDep) -> FoodR
             "Food type is immutable and cannot be changed after creation",
         )
 
-    changes = payload.model_dump(exclude_unset=True, exclude={"type"})
+    changes = payload.model_dump(exclude_unset=True, exclude={"type", "set_default_for_all_cats"})
     for field, value in changes.items():
         setattr(food, field, value)
 
+    defaulted = (
+        _apply_default_for_all_cats(session, food) if payload.set_default_for_all_cats else 0
+    )
+
     session.commit()
     session.refresh(food)
-    return FoodResponse.model_validate(food)
+    return FoodMutationResult(
+        food=FoodResponse.model_validate(food), defaulted_for_cat_count=defaulted
+    )
 
 
 @router.delete("/foods/{food_id}")

--- a/backend/app/routers/foods.py
+++ b/backend/app/routers/foods.py
@@ -36,6 +36,20 @@ def _get_food_or_404(session: Session, food_id: int) -> Food:
     return food
 
 
+def ensure_food_not_archived(food: Food) -> None:
+    """Shared 400 guard: an archived food can never become a cat's default.
+
+    Used here and by ``cats._validate_default_food`` so the bulk (set-for-all)
+    and per-cat default paths can't drift out of sync on this rule.
+    """
+
+    if food.archived_at is not None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Food {food.id} is archived and cannot be a default",
+        )
+
+
 def _apply_default_for_all_cats(session: Session, food: Food) -> int:
     """Point every cat's matching (wet/dry) default at ``food``; return the count.
 
@@ -50,11 +64,7 @@ def _apply_default_for_all_cats(session: Session, food: Food) -> int:
             status.HTTP_400_BAD_REQUEST,
             "A treat cannot be set as a default wet/dry food",
         )
-    if food.archived_at is not None:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"Food {food.id} is archived and cannot be a default",
-        )
+    ensure_food_not_archived(food)
 
     cats = session.scalars(select(Cat)).all()
     for cat in cats:

--- a/backend/app/routers/target.py
+++ b/backend/app/routers/target.py
@@ -1,11 +1,22 @@
 """Target-calorie calculator endpoint (``GET /api/target-suggestion``).
 
-Loads the cat's goal weight and current weight (latest weigh-in) and returns the
-RER/MER breakdown. Unknown cat → 404; a cat with neither a goal weight nor any
-weight entry has nothing to compute from → 400.
+Two mutually exclusive modes, exactly one of which must be requested:
+
+- **By cat** (``?cat_id=``): loads the cat's goal weight and current weight
+  (latest weigh-in) and returns the RER/MER breakdown. Unknown cat → 404; a cat
+  with neither a goal weight nor any weight entry has nothing to compute from →
+  400.
+- **By weight** (``?weight_kg=`` with optional ``&goal_weight_kg=``): computes
+  from explicit weights for onboarding a cat that does not exist yet. ``cat_id``
+  is null in the response.
+
+Supplying neither or both modes (or ``goal_weight_kg`` alongside ``cat_id``) is a
+malformed request → 422.
 """
 
-from fastapi import APIRouter, HTTPException, status
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 
 from app.db import SessionDep
@@ -17,7 +28,29 @@ router = APIRouter(tags=["target"])
 
 
 @router.get("/target-suggestion")
-def target_suggestion(session: SessionDep, cat_id: int) -> TargetSuggestionResponse:
+def target_suggestion(
+    session: SessionDep,
+    cat_id: Annotated[int | None, Query()] = None,
+    weight_kg: Annotated[float | None, Query(gt=0)] = None,
+    goal_weight_kg: Annotated[float | None, Query(gt=0)] = None,
+) -> TargetSuggestionResponse:
+    if (cat_id is None) == (weight_kg is None):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "Provide exactly one of cat_id or weight_kg",
+        )
+
+    if weight_kg is not None:
+        # By-weight onboarding mode: the supplied weight is treated as the
+        # current weight; goal_weight_kg (if any) still takes precedence in the math.
+        return compute_target_suggestion(None, goal_weight_kg, weight_kg)
+
+    if goal_weight_kg is not None:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "goal_weight_kg applies only to the by-weight mode, not with cat_id",
+        )
+
     cat = session.get(Cat, cat_id)
     if cat is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Cat {cat_id} not found")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -43,6 +43,9 @@ class FoodCreate(BaseModel):
     type: FoodType
     calorie_basis: CalorieBasis
     kcal_per_basis: PositiveFloat
+    # When true (and type is WET/DRY), point every cat's matching default at this
+    # food in the same transaction. A no-op for TREAT — rejected in the router.
+    set_default_for_all_cats: bool = False
 
 
 class FoodUpdate(BaseModel):
@@ -51,6 +54,8 @@ class FoodUpdate(BaseModel):
     kcal_per_basis: OptionalPositiveFloat = None
     # Accepted only to reject changes explicitly (type is immutable → 400).
     type: FoodType | None = None
+    # See FoodCreate; on edit the food's type/archived state is checked live.
+    set_default_for_all_cats: bool = False
 
     @model_validator(mode="after")
     def _no_explicit_nulls(self) -> FoodUpdate:
@@ -80,6 +85,18 @@ class FoodDeleteResult(BaseModel):
     archived: bool
     food: FoodResponse | None
     cleared_default_for_cat_ids: list[int]
+
+
+class FoodMutationResult(BaseModel):
+    """Outcome of ``POST /foods`` and ``PATCH /foods/{id}``.
+
+    ``defaulted_for_cat_count`` is the number of cats whose matching default was
+    pointed at this food by ``set_default_for_all_cats`` (0 when the flag was
+    not set), so the UI can say "set as default for N cats".
+    """
+
+    food: FoodResponse
+    defaulted_for_cat_count: int
 
 
 # --- Weights ---------------------------------------------------------------
@@ -317,9 +334,12 @@ class TargetSuggestionResponse(BaseModel):
     weight (factor 0.8, weight loss) when a goal is set, otherwise the current
     weight (factor 1.2, neutered-adult maintenance).
     ``suggested_target_kcal = rer_kcal x factor``.
+
+    ``cat_id`` is null in the by-weight mode (onboarding a cat that does not
+    exist yet), where the weights come straight from the query params.
     """
 
-    cat_id: int
+    cat_id: int | None
     current_weight_kg: float | None
     goal_weight_kg: float | None
     rer_kcal: float

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -44,7 +44,7 @@ class FoodCreate(BaseModel):
     calorie_basis: CalorieBasis
     kcal_per_basis: PositiveFloat
     # When true (and type is WET/DRY), point every cat's matching default at this
-    # food in the same transaction. A no-op for TREAT — rejected in the router.
+    # food in the same transaction. Rejected with 400 for TREAT (not a no-op).
     set_default_for_all_cats: bool = False
 
 

--- a/backend/app/services/target.py
+++ b/backend/app/services/target.py
@@ -27,11 +27,15 @@ def _rer_kcal(weight_kg: float) -> float:
 
 
 def compute_target_suggestion(
-    cat_id: int,
+    cat_id: int | None,
     goal_weight_kg: float | None,
     current_weight_kg: float | None,
 ) -> TargetSuggestionResponse:
-    """Build the calculator payload, preferring the goal weight when present."""
+    """Build the calculator payload, preferring the goal weight when present.
+
+    ``cat_id`` is null in the by-weight onboarding mode; there a weight is always
+    supplied so the "no weight to compute from" branch is never reached.
+    """
 
     if goal_weight_kg is not None:
         basis = TargetBasis.GOAL_WEIGHT

--- a/backend/app/services/target.py
+++ b/backend/app/services/target.py
@@ -33,7 +33,7 @@ def compute_target_suggestion(
 ) -> TargetSuggestionResponse:
     """Build the calculator payload, preferring the goal weight when present.
 
-    ``cat_id`` is null in the by-weight onboarding mode; there a weight is always
+    ``cat_id`` is null in the by-weight onboarding mode; where a weight is always
     supplied so the "no weight to compute from" branch is never reached.
     """
 
@@ -46,7 +46,8 @@ def compute_target_suggestion(
         basis_weight = current_weight_kg
         factor = MAINTENANCE_FACTOR
     else:
-        msg = f"Cat {cat_id} has no goal weight and no weight entries to compute a target from"
+        subject = f"Cat {cat_id}" if cat_id is not None else "This cat"
+        msg = f"{subject} has no goal weight and no weight entries to compute a target from"
         raise InsufficientWeightDataError(msg)
 
     rer = _rer_kcal(basis_weight)

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -16,7 +16,8 @@ def create_food(client: TestClient, **overrides: Any) -> dict[str, Any]:
     payload.update(overrides)
     response = client.post("/api/foods", json=payload)
     assert response.status_code == 201, response.text
-    body: dict[str, Any] = response.json()
+    # POST /foods wraps the food in a FoodMutationResult; unwrap for callers.
+    body: dict[str, Any] = response.json()["food"]
     return body
 
 

--- a/backend/tests/test_cats.py
+++ b/backend/tests/test_cats.py
@@ -22,6 +22,14 @@ def test_create_with_initial_weight_creates_first_entry(client: TestClient) -> N
     assert weights[0]["weight_kg"] == 4.2
 
 
+def test_create_with_default_foods(client: TestClient) -> None:
+    wet = create_food(client, type="WET")
+    dry = create_food(client, type="DRY", calorie_basis="PER_100G")
+    cat = create_cat(client, default_wet_food_id=wet["id"], default_dry_food_id=dry["id"])
+    assert cat["default_wet_food_id"] == wet["id"]
+    assert cat["default_dry_food_id"] == dry["id"]
+
+
 def test_default_food_must_exist(client: TestClient) -> None:
     response = client.post(
         "/api/cats", json={"name": "X", "target_kcal": 200.0, "default_wet_food_id": 999}

--- a/backend/tests/test_foods.py
+++ b/backend/tests/test_foods.py
@@ -38,7 +38,7 @@ def test_calorie_fields_are_editable(client: TestClient) -> None:
         json={"kcal_per_basis": 95.0, "calorie_basis": "PER_100G", "name": "Renamed"},
     )
     assert response.status_code == 200
-    body = response.json()
+    body = response.json()["food"]
     assert body["kcal_per_basis"] == 95.0
     assert body["name"] == "Renamed"
 
@@ -101,3 +101,99 @@ def test_cannot_log_archived_food(client: TestClient) -> None:
         "/api/meals", json={"cat_id": cat["id"], "food_id": food["id"], "quantity": 10.0}
     )
     assert response.status_code == 400
+
+
+# --- Set-default-for-all-cats ----------------------------------------------
+
+
+def test_create_wet_food_as_default_for_all_cats(client: TestClient) -> None:
+    a = create_cat(client, name="A")
+    b = create_cat(client, name="B")
+    response = client.post(
+        "/api/foods",
+        json={
+            "name": "House Wet",
+            "type": "WET",
+            "calorie_basis": "PER_100G",
+            "kcal_per_basis": 80.0,
+            "set_default_for_all_cats": True,
+        },
+    )
+    assert response.status_code == 201
+    result = response.json()
+    assert result["defaulted_for_cat_count"] == 2
+    food_id = result["food"]["id"]
+    cats = {cat["id"]: cat for cat in client.get("/api/cats").json()}
+    assert cats[a["id"]]["default_wet_food_id"] == food_id
+    assert cats[b["id"]]["default_wet_food_id"] == food_id
+
+
+def test_edit_dry_food_as_default_for_all_cats(client: TestClient) -> None:
+    create_cat(client, name="A")
+    dry = create_food(client, type="DRY")
+    response = client.patch(f"/api/foods/{dry['id']}", json={"set_default_for_all_cats": True})
+    assert response.status_code == 200
+    assert response.json()["defaulted_for_cat_count"] == 1
+    assert client.get("/api/cats").json()[0]["default_dry_food_id"] == dry["id"]
+
+
+def test_create_without_flag_defaults_nothing(client: TestClient) -> None:
+    create_cat(client)
+    response = client.post(
+        "/api/foods",
+        json={
+            "name": "Just Food",
+            "type": "WET",
+            "calorie_basis": "PER_100G",
+            "kcal_per_basis": 80.0,
+        },
+    )
+    assert response.json()["defaulted_for_cat_count"] == 0
+    assert client.get("/api/cats").json()[0]["default_wet_food_id"] is None
+
+
+def test_set_default_for_all_cats_rejects_treat(client: TestClient) -> None:
+    create_cat(client)
+    response = client.post(
+        "/api/foods",
+        json={
+            "name": "Churu",
+            "type": "TREAT",
+            "calorie_basis": "PER_PIECE",
+            "kcal_per_basis": 6.0,
+            "set_default_for_all_cats": True,
+        },
+    )
+    assert response.status_code == 400
+    # The whole request rolled back — the treat was not created.
+    assert client.get("/api/foods?include_archived=true").json() == []
+
+
+def test_set_default_for_all_cats_rejects_archived_food(client: TestClient) -> None:
+    cat = create_cat(client)
+    wet = create_food(client, type="WET")
+    create_meal(client, cat_id=cat["id"], food_id=wet["id"])
+    client.delete(f"/api/foods/{wet['id']}")  # archives it (referenced by a meal)
+
+    response = client.patch(f"/api/foods/{wet['id']}", json={"set_default_for_all_cats": True})
+    assert response.status_code == 400
+
+
+def test_bulk_default_leaves_existing_meal_snapshots_untouched(client: TestClient) -> None:
+    cat = create_cat(client)
+    wet = create_food(client, type="WET", kcal_per_basis=80.0, calorie_basis="PER_100G")
+    meal = create_meal(client, cat_id=cat["id"], food_id=wet["id"], quantity=100.0)
+    original_kcal = meal["kcal"]  # 100 g at 80 kcal/100 g → 80 kcal
+
+    # Edit the food's kcal AND set it as default for all cats in one request.
+    response = client.patch(
+        f"/api/foods/{wet['id']}",
+        json={"kcal_per_basis": 200.0, "set_default_for_all_cats": True},
+    )
+    assert response.status_code == 200
+    assert response.json()["defaulted_for_cat_count"] == 1
+    assert client.get("/api/cats").json()[0]["default_wet_food_id"] == wet["id"]
+
+    # The already-logged meal keeps its snapshot calories despite the kcal edit.
+    meals = client.get("/api/meals").json()
+    assert meals[0]["kcal"] == original_kcal

--- a/backend/tests/test_target.py
+++ b/backend/tests/test_target.py
@@ -98,3 +98,52 @@ def test_endpoint_unknown_cat_404(client: TestClient) -> None:
 def test_endpoint_no_goal_no_weight_400(client: TestClient) -> None:
     cat = create_cat(client, target_kcal=200.0)  # no goal, no weigh-in
     assert client.get(f"/api/target-suggestion?cat_id={cat['id']}").status_code == 400
+
+
+# --- By-weight mode (onboarding, no cat yet) -------------------------------
+
+
+def test_endpoint_by_weight_current_basis(client: TestClient) -> None:
+    body = client.get("/api/target-suggestion?weight_kg=5.0").json()
+
+    assert body["cat_id"] is None
+    assert body["basis"] == "CURRENT_WEIGHT"
+    assert body["current_weight_kg"] == 5.0
+    assert body["goal_weight_kg"] is None
+    assert body["factor"] == 1.2
+    assert body["rer_kcal"] == pytest.approx(RER_5KG)
+    assert body["suggested_target_kcal"] == pytest.approx(RER_5KG * 1.2)
+
+
+def test_endpoint_by_weight_with_goal_uses_goal_basis(client: TestClient) -> None:
+    body = client.get("/api/target-suggestion?weight_kg=5.0&goal_weight_kg=4.0").json()
+
+    assert body["cat_id"] is None
+    assert body["basis"] == "GOAL_WEIGHT"
+    assert body["current_weight_kg"] == 5.0
+    assert body["goal_weight_kg"] == 4.0
+    assert body["factor"] == 0.8
+    # RER computed on the GOAL weight (4 kg), not the entered current weight.
+    assert body["rer_kcal"] == pytest.approx(RER_4KG)
+    assert body["suggested_target_kcal"] == pytest.approx(RER_4KG * 0.8)
+
+
+def test_endpoint_requires_a_mode(client: TestClient) -> None:
+    assert client.get("/api/target-suggestion").status_code == 422
+
+
+def test_endpoint_rejects_both_modes(client: TestClient) -> None:
+    cat = create_cat(client, target_kcal=200.0, goal_weight_kg=4.0)
+    response = client.get(f"/api/target-suggestion?cat_id={cat['id']}&weight_kg=5.0")
+    assert response.status_code == 422
+
+
+def test_endpoint_rejects_goal_weight_alongside_cat_id(client: TestClient) -> None:
+    cat = create_cat(client, target_kcal=200.0, goal_weight_kg=4.0)
+    response = client.get(f"/api/target-suggestion?cat_id={cat['id']}&goal_weight_kg=3.5")
+    assert response.status_code == 422
+
+
+def test_endpoint_by_weight_rejects_nonpositive_weight(client: TestClient) -> None:
+    assert client.get("/api/target-suggestion?weight_kg=0").status_code == 422
+    assert client.get("/api/target-suggestion?weight_kg=-1").status_code == 422

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,9 +219,14 @@ class-strategy with a system fallback, all in `frontend/src/lib/theme.ts` and
 
 - `lib/theme.ts` persists the mode (`light`/`dark`/`system`) in `localStorage`
   and reflects it onto `<html>` as a `data-theme` attribute — set to
-  `light`/`dark` for an explicit choice, **removed** for `system`. `useThemeMode`
-  applies it and, while in system mode, subscribes to `matchMedia` so
-  `resolvedTheme` tracks OS changes (the CSS already repaints on its own).
+  `light`/`dark` for an explicit choice, **removed** for `system`. `mode` and
+  the current OS preference live in one module-level store (subscribed to via
+  `useSyncExternalStore`), not per-hook `useState`, so every `useThemeMode`
+  consumer (the Settings toggle, the `Toaster`, ...) re-renders together on a
+  change instead of drifting out of sync until a remount. The store tracks
+  `matchMedia` unconditionally (not just while in system mode), so switching
+  back to system mode is never stale — the CSS itself still does the actual
+  repaint via the media query.
 - `index.css` defines the design tokens so dark applies **both** under
   `[data-theme="dark"]` (explicit) and under
   `@media (prefers-color-scheme: dark)` scoped to `:root:not([data-theme])`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,6 +210,32 @@ frontend never computes calories; it only renders what these return.
   never fall back to the browser's own local date, since the viewer and
   household timezones can differ.
 
+## Theming
+
+Light / dark / system, chosen from a three-way toggle in Settings
+(`frontend/src/components/settings/theme-toggle.tsx`). The mechanism is
+class-strategy with a system fallback, all in `frontend/src/lib/theme.ts` and
+`frontend/src/index.css` — no `next-themes` or other theme library:
+
+- `lib/theme.ts` persists the mode (`light`/`dark`/`system`) in `localStorage`
+  and reflects it onto `<html>` as a `data-theme` attribute — set to
+  `light`/`dark` for an explicit choice, **removed** for `system`. `useThemeMode`
+  applies it and, while in system mode, subscribes to `matchMedia` so
+  `resolvedTheme` tracks OS changes (the CSS already repaints on its own).
+- `index.css` defines the design tokens so dark applies **both** under
+  `[data-theme="dark"]` (explicit) and under
+  `@media (prefers-color-scheme: dark)` scoped to `:root:not([data-theme])`
+  (system default); light lives on `:root, [data-theme="light"]`. The Tailwind
+  `dark:` variant is redefined to match the same two conditions. Absent/invalid
+  storage ⇒ system, identical to the app's original behavior.
+- A tiny inline script in `index.html` applies the stored mode in `<head>`
+  before first paint, so there's no flash of the wrong theme.
+- Charts follow automatically: their `ChartConfig`s reference `color:
+  var(--chart-N)`, and those CSS variables flip with the tokens above — the
+  chart `theme` key is deliberately not used. The PWA `theme-color` metas still
+  key off `prefers-color-scheme` (OS only), an accepted limitation for the
+  status-bar color.
+
 ## Strictness profiles
 
 - **Backend:** `ruff` lints with 38 rule groups selected (`backend/pyproject.toml`

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,11 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Feeding, calorie, and weight tracker for the household cats." />
+    <!--
+      theme-color tracks the OS preference only (media attribute). The in-app
+      three-way toggle (light/dark/system) overrides the page tokens but not this
+      PWA status-bar color; that's an accepted limitation — see FEATURE_PARITY.md.
+    -->
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <meta name="mobile-web-app-capable" content="yes" />
@@ -14,6 +19,19 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Cat Tracker" />
     <title>Cat Tracker</title>
+    <script>
+      // Apply the stored theme before first paint to avoid a flash. Mirrors
+      // lib/theme.ts: 'light'/'dark' set data-theme; 'system' or absent leaves it
+      // off so the prefers-color-scheme media query in index.css takes over.
+      (function () {
+        try {
+          var mode = localStorage.getItem('cat-tracker-theme')
+          if (mode === 'light' || mode === 'dark') {
+            document.documentElement.setAttribute('data-theme', mode)
+          }
+        } catch (e) {}
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -13,6 +13,7 @@ import type {
   Food,
   FoodCreate,
   FoodDeleteResult,
+  FoodMutationResult,
   FoodUpdate,
   Meal,
   MealCreate,
@@ -29,8 +30,8 @@ import type {
 export const foodsApi = {
   list: (includeArchived = false) =>
     api.get<Food[]>(`/foods${queryString({ include_archived: includeArchived || undefined })}`),
-  create: (body: FoodCreate) => api.post<Food>('/foods', body),
-  update: (id: number, body: FoodUpdate) => api.patch<Food>(`/foods/${id}`, body),
+  create: (body: FoodCreate) => api.post<FoodMutationResult>('/foods', body),
+  update: (id: number, body: FoodUpdate) => api.patch<FoodMutationResult>(`/foods/${id}`, body),
   remove: (id: number) => api.delete<FoodDeleteResult>(`/foods/${id}`),
 }
 
@@ -74,4 +75,9 @@ export const settingsApi = {
 export const targetSuggestionApi = {
   get: (catId: number) =>
     api.get<TargetSuggestion>(`/target-suggestion${queryString({ cat_id: catId })}`),
+  // Onboarding mode: compute from explicit weights before a cat exists.
+  getByWeight: (weightKg: number, goalWeightKg?: number) =>
+    api.get<TargetSuggestion>(
+      `/target-suggestion${queryString({ weight_kg: weightKg, goal_weight_kg: goalWeightKg })}`,
+    ),
 }

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -166,6 +166,22 @@ export function useTargetSuggestion(catId: number, enabled: boolean) {
   })
 }
 
+/**
+ * By-weight calculator for cat onboarding (no cat exists yet). Enabled only once
+ * a positive weight has been entered; keyed on the weights so editing them refetches.
+ */
+export function useTargetSuggestionByWeight(
+  weightKg: number | null,
+  goalWeightKg: number | null,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.targetSuggestionByWeight(weightKg ?? 0, goalWeightKg ?? undefined),
+    queryFn: () => targetSuggestionApi.getByWeight(weightKg ?? 0, goalWeightKg ?? undefined),
+    enabled: enabled && weightKg !== null && weightKg > 0,
+  })
+}
+
 // --- Meals -----------------------------------------------------------------
 
 /** Meal list. `catId` (camelCase, query-key shape) maps to the API's `cat_id`. */

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -50,6 +50,9 @@ export const queryKeys = {
     all: ['settings'] as const,
   },
   targetSuggestion: (catId: number) => ['target-suggestion', catId] as const,
+  // Onboarding calculator, keyed on the entered weights (no cat yet).
+  targetSuggestionByWeight: (weightKg: number, goalWeightKg?: number) =>
+    ['target-suggestion', 'by-weight', weightKg, goalWeightKg ?? null] as const,
   reports: {
     all: ['reports'] as const,
     today: () => ['reports', 'today'] as const,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -415,6 +415,11 @@ export interface components {
             calorie_basis: components["schemas"]["CalorieBasis"];
             /** Kcal Per Basis */
             kcal_per_basis: number;
+            /**
+             * Set Default For All Cats
+             * @default false
+             */
+            set_default_for_all_cats: boolean;
         };
         /**
          * FoodDeleteResult
@@ -430,6 +435,19 @@ export interface components {
             food: components["schemas"]["FoodResponse"] | null;
             /** Cleared Default For Cat Ids */
             cleared_default_for_cat_ids: number[];
+        };
+        /**
+         * FoodMutationResult
+         * @description Outcome of ``POST /foods`` and ``PATCH /foods/{id}``.
+         *
+         *     ``defaulted_for_cat_count`` is the number of cats whose matching default was
+         *     pointed at this food by ``set_default_for_all_cats`` (0 when the flag was
+         *     not set), so the UI can say "set as default for N cats".
+         */
+        FoodMutationResult: {
+            food: components["schemas"]["FoodResponse"];
+            /** Defaulted For Cat Count */
+            defaulted_for_cat_count: number;
         };
         /** FoodResponse */
         FoodResponse: {
@@ -457,6 +475,11 @@ export interface components {
             /** Kcal Per Basis */
             kcal_per_basis?: number | null;
             type?: components["schemas"]["FoodType"] | null;
+            /**
+             * Set Default For All Cats
+             * @default false
+             */
+            set_default_for_all_cats: boolean;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -619,14 +642,17 @@ export interface components {
          * TargetSuggestionResponse
          * @description RER/MER breakdown for the calculator dialog (always a suggestion).
          *
-         *     ``rer_kcal = 70 × basis_weight ** 0.75`` where the basis weight is the goal
+         *     ``rer_kcal = 70 x basis_weight ** 0.75`` where the basis weight is the goal
          *     weight (factor 0.8, weight loss) when a goal is set, otherwise the current
          *     weight (factor 1.2, neutered-adult maintenance).
-         *     ``suggested_target_kcal = rer_kcal × factor``.
+         *     ``suggested_target_kcal = rer_kcal x factor``.
+         *
+         *     ``cat_id`` is null in the by-weight mode (onboarding a cat that does not
+         *     exist yet), where the weights come straight from the query params.
          */
         TargetSuggestionResponse: {
             /** Cat Id */
-            cat_id: number;
+            cat_id: number | null;
             /** Current Weight Kg */
             current_weight_kg: number | null;
             /** Goal Weight Kg */
@@ -1021,7 +1047,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FoodResponse"];
+                    "application/json": components["schemas"]["FoodMutationResult"];
                 };
             };
             /** @description Validation Error */
@@ -1087,7 +1113,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FoodResponse"];
+                    "application/json": components["schemas"]["FoodMutationResult"];
                 };
             };
             /** @description Validation Error */
@@ -1403,8 +1429,10 @@ export interface operations {
     };
     target_suggestion_api_target_suggestion_get: {
         parameters: {
-            query: {
-                cat_id: number;
+            query?: {
+                cat_id?: number | null;
+                weight_kg?: number | null;
+                goal_weight_kg?: number | null;
             };
             header?: never;
             path?: never;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -15,6 +15,7 @@ export type Food = Schemas['FoodResponse']
 export type FoodCreate = Schemas['FoodCreate']
 export type FoodUpdate = Schemas['FoodUpdate']
 export type FoodDeleteResult = Schemas['FoodDeleteResult']
+export type FoodMutationResult = Schemas['FoodMutationResult']
 
 export type Cat = Schemas['CatResponse']
 export type CatCreate = Schemas['CatCreate']

--- a/frontend/src/components/settings/cat-form-dialog.test.tsx
+++ b/frontend/src/components/settings/cat-form-dialog.test.tsx
@@ -1,0 +1,156 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, expect, test, vi } from 'vitest'
+import type { Food, TargetSuggestion } from '@/api/types'
+import { installFetchMock } from '@/test/mock-api'
+import { renderWithProviders } from '@/test/render'
+import { CatFormDialog } from './cat-form-dialog'
+
+const wet: Food = {
+  id: 1,
+  name: 'Tuna Feast',
+  type: 'WET',
+  calorie_basis: 'PER_100G',
+  kcal_per_basis: 85,
+  archived_at: null,
+}
+const dry: Food = {
+  id: 2,
+  name: 'Kibble',
+  type: 'DRY',
+  calorie_basis: 'PER_100G',
+  kcal_per_basis: 350,
+  archived_at: null,
+}
+
+// By-weight suggestion (cat_id null); Math.round(280.9) → 281 for the fill.
+const suggestion: TargetSuggestion = {
+  cat_id: null,
+  current_weight_kg: 5.0,
+  goal_weight_kg: null,
+  rer_kcal: 234.1,
+  factor: 1.2,
+  basis: 'CURRENT_WEIGHT',
+  suggested_target_kcal: 280.9,
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('entering a weight fetches the suggestion and prefills the target', async () => {
+  installFetchMock([
+    { method: 'GET', path: '/api/foods', body: [] },
+    { method: 'GET', path: '/api/target-suggestion', body: suggestion },
+  ])
+
+  renderWithProviders(<CatFormDialog open onOpenChange={() => {}} />)
+
+  await userEvent.type(screen.getByLabelText('Initial weight (kg)'), '5')
+
+  expect(await screen.findByText('Suggested target')).toBeInTheDocument()
+  await waitFor(() =>
+    expect(screen.getByLabelText('Daily target (kcal)')).toHaveValue(281),
+  )
+})
+
+test('the Use button fills the target and a manual edit overrides the suggestion', async () => {
+  installFetchMock([
+    { method: 'GET', path: '/api/foods', body: [] },
+    { method: 'GET', path: '/api/target-suggestion', body: suggestion },
+  ])
+
+  renderWithProviders(<CatFormDialog open onOpenChange={() => {}} />)
+
+  await userEvent.type(screen.getByLabelText('Initial weight (kg)'), '5')
+  const target = screen.getByLabelText('Daily target (kcal)')
+  await waitFor(() => expect(target).toHaveValue(281))
+
+  // Manual override wins: the auto-prefill must not clobber a hand-typed value.
+  await userEvent.clear(target)
+  await userEvent.type(target, '150')
+  expect(target).toHaveValue(150)
+
+  // The Use button re-applies the suggestion on demand.
+  await userEvent.click(screen.getByRole('button', { name: /use 281 kcal/i }))
+  expect(target).toHaveValue(281)
+})
+
+test('degrades gracefully with no weight: no suggestion, manual target still submits', async () => {
+  const created = {
+    id: 7,
+    name: 'Whiskers',
+    target_kcal: 200,
+    goal_weight_kg: null,
+    default_wet_food_id: null,
+    default_dry_food_id: null,
+    current_weight_kg: null,
+    meal_count: 0,
+  }
+  const calls = installFetchMock([
+    { method: 'GET', path: '/api/foods', body: [] },
+    { method: 'POST', path: '/api/cats', status: 201, body: created },
+  ])
+  const onOpenChange = vi.fn()
+
+  renderWithProviders(<CatFormDialog open onOpenChange={onOpenChange} />)
+
+  await userEvent.type(screen.getByLabelText('Name'), 'Whiskers')
+  await userEvent.type(screen.getByLabelText('Daily target (kcal)'), '200')
+
+  expect(screen.queryByText('Suggested target')).not.toBeInTheDocument()
+
+  await userEvent.click(screen.getByRole('button', { name: 'Add cat' }))
+
+  const post = await waitFor(() => {
+    const call = calls.find((c) => c.method === 'POST')
+    expect(call).toBeDefined()
+    return call!
+  })
+  expect(post.body).toMatchObject({ name: 'Whiskers', target_kcal: 200 })
+  // No weight was entered, so the calculator was never called.
+  expect(calls.some((c) => c.path === '/api/target-suggestion')).toBe(false)
+  expect(onOpenChange).toHaveBeenCalledWith(false)
+})
+
+test('create mode offers default-food selects and sends the chosen wet default', async () => {
+  const created = {
+    id: 7,
+    name: 'Whiskers',
+    target_kcal: 200,
+    goal_weight_kg: null,
+    default_wet_food_id: 1,
+    default_dry_food_id: null,
+    current_weight_kg: null,
+    meal_count: 0,
+  }
+  const calls = installFetchMock([
+    { method: 'GET', path: '/api/foods', body: [wet, dry] },
+    { method: 'POST', path: '/api/cats', status: 201, body: created },
+  ])
+
+  renderWithProviders(<CatFormDialog open onOpenChange={() => {}} />)
+
+  await userEvent.type(screen.getByLabelText('Name'), 'Whiskers')
+  await userEvent.type(screen.getByLabelText('Daily target (kcal)'), '200')
+
+  await userEvent.click(await screen.findByRole('combobox', { name: 'Default wet food' }))
+  await userEvent.click(await screen.findByRole('option', { name: 'Tuna Feast' }))
+
+  await userEvent.click(screen.getByRole('button', { name: 'Add cat' }))
+
+  const post = await waitFor(() => {
+    const call = calls.find((c) => c.method === 'POST')
+    expect(call).toBeDefined()
+    return call!
+  })
+  expect(post.body).toMatchObject({ default_wet_food_id: 1, default_dry_food_id: null })
+})
+
+test('an empty food library shows the add-foods empty state for both selects', async () => {
+  installFetchMock([{ method: 'GET', path: '/api/foods', body: [] }])
+
+  renderWithProviders(<CatFormDialog open onOpenChange={() => {}} />)
+
+  expect(await screen.findAllByText('Add foods in Settings first')).toHaveLength(2)
+})

--- a/frontend/src/components/settings/cat-form-dialog.test.tsx
+++ b/frontend/src/components/settings/cat-form-dialog.test.tsx
@@ -1,7 +1,10 @@
-import { screen, waitFor } from '@testing-library/react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, expect, test, vi } from 'vitest'
+import { createQueryClient } from '@/api/query-client'
 import type { Food, TargetSuggestion } from '@/api/types'
+import { Toaster } from '@/components/ui/sonner'
 import { installFetchMock } from '@/test/mock-api'
 import { renderWithProviders } from '@/test/render'
 import { CatFormDialog } from './cat-form-dialog'
@@ -153,4 +156,54 @@ test('an empty food library shows the add-foods empty state for both selects', a
   renderWithProviders(<CatFormDialog open onOpenChange={() => {}} />)
 
   expect(await screen.findAllByText('Add foods in Settings first')).toHaveLength(2)
+})
+
+test('clearing the weight after a suggestion was applied resets the target', async () => {
+  installFetchMock([
+    { method: 'GET', path: '/api/foods', body: [] },
+    { method: 'GET', path: '/api/target-suggestion', body: suggestion },
+  ])
+
+  renderWithProviders(<CatFormDialog open onOpenChange={() => {}} />)
+
+  const weightInput = screen.getByLabelText('Initial weight (kg)')
+  await userEvent.type(weightInput, '5')
+  await waitFor(() => expect(screen.getByLabelText('Daily target (kcal)')).toHaveValue(281))
+
+  // Removing the weight removes the basis for the suggestion — the stale
+  // calculated target must not linger and get submitted for a weight that's no
+  // longer entered.
+  await userEvent.clear(weightInput)
+  await waitFor(() => expect(screen.getByLabelText('Daily target (kcal)')).toHaveValue(null))
+})
+
+test('reopening the create dialog after entering a weight does not reapply a stale suggestion', async () => {
+  installFetchMock([
+    { method: 'GET', path: '/api/foods', body: [] },
+    { method: 'GET', path: '/api/target-suggestion', body: suggestion },
+  ])
+
+  // Mirrors how CatsCard mounts the "Add cat" dialog: always mounted, only
+  // `open` toggles — so the component instance (and its state) persists across
+  // a close/reopen, which is what the stale-suggestion regression depends on.
+  const queryClient = createQueryClient()
+  function Harness({ open }: { open: boolean }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <CatFormDialog open={open} onOpenChange={() => {}} />
+        <Toaster />
+      </QueryClientProvider>
+    )
+  }
+
+  const { rerender } = render(<Harness open />)
+
+  await userEvent.type(screen.getByLabelText('Initial weight (kg)'), '5')
+  await waitFor(() => expect(screen.getByLabelText('Daily target (kcal)')).toHaveValue(281))
+
+  rerender(<Harness open={false} />)
+  rerender(<Harness open />)
+
+  expect(screen.getByLabelText('Initial weight (kg)')).toHaveValue(null)
+  expect(screen.getByLabelText('Daily target (kcal)')).toHaveValue(null)
 })

--- a/frontend/src/components/settings/cat-form-dialog.tsx
+++ b/frontend/src/components/settings/cat-form-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { useCreateCat, useFoods, useUpdateCat } from '@/api/hooks'
+import { useCreateCat, useFoods, useTargetSuggestionByWeight, useUpdateCat } from '@/api/hooks'
 import type { Cat, FoodType } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { parsePositiveNumber } from '@/lib/format'
+import { formatKcal, formatKg, parsePositiveNumber } from '@/lib/format'
 
 /** Radix Select forbids an empty-string item value; sentinel for “no default food”. */
 const NONE = 'none'
@@ -40,6 +40,9 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
 
   const [name, setName] = useState('')
   const [targetKcal, setTargetKcal] = useState('')
+  // Tracks whether the user hand-edited the target; once true, the by-weight
+  // suggestion stops auto-filling it (manual override wins).
+  const [targetTouched, setTargetTouched] = useState(false)
   const [goalWeight, setGoalWeight] = useState('')
   const [initialWeight, setInitialWeight] = useState('')
   const [wetFoodId, setWetFoodId] = useState(NONE)
@@ -50,12 +53,27 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
     if (!open) return
     setName(cat?.name ?? '')
     setTargetKcal(cat ? String(cat.target_kcal) : '')
+    setTargetTouched(false)
     setGoalWeight(cat?.goal_weight_kg != null ? String(cat.goal_weight_kg) : '')
     setInitialWeight('')
     setWetFoodId(cat?.default_wet_food_id != null ? String(cat.default_wet_food_id) : NONE)
     setDryFoodId(cat?.default_dry_food_id != null ? String(cat.default_dry_food_id) : NONE)
     setError(null)
   }, [open, cat])
+
+  // Onboarding calculator: once a weight is entered (create mode only), fetch the
+  // RER/MER suggestion from the entered weight and optional goal weight.
+  const weightForSuggestion = cat ? null : parsePositiveNumber(initialWeight)
+  const goalForSuggestion = goalWeight.trim() === '' ? null : parsePositiveNumber(goalWeight)
+  const suggestion = useTargetSuggestionByWeight(weightForSuggestion, goalForSuggestion, open && !cat)
+  const suggestedTarget = suggestion.data ? Math.round(suggestion.data.suggested_target_kcal) : null
+
+  // Prefill the target from the suggestion while the user hasn't typed their own —
+  // keeps it in sync as they adjust the weight, but never clobbers a manual value.
+  useEffect(() => {
+    if (cat || targetTouched || suggestedTarget === null) return
+    setTargetKcal(String(suggestedTarget))
+  }, [cat, targetTouched, suggestedTarget])
 
   const pending = createCat.isPending || updateCat.isPending
 
@@ -115,8 +133,44 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
         target_kcal: target,
         goal_weight_kg: goal,
         initial_weight_kg: initial,
+        default_wet_food_id: wetFoodId === NONE ? null : Number(wetFoodId),
+        default_dry_food_id: dryFoodId === NONE ? null : Number(dryFoodId),
       },
       { onSuccess, onError },
+    )
+  }
+
+  function defaultFoodField(
+    type: FoodType,
+    id: string,
+    label: string,
+    value: string,
+    onValueChange: (value: string) => void,
+  ) {
+    const options = foodOptions(type)
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor={id}>{label}</Label>
+        {options.length === 0 ? (
+          <p id={id} className="flex min-h-9 items-center text-sm text-muted-foreground">
+            Add foods in Settings first
+          </p>
+        ) : (
+          <Select value={value} onValueChange={onValueChange}>
+            <SelectTrigger id={id} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE}>None</SelectItem>
+              {options.map((food) => (
+                <SelectItem key={food.id} value={String(food.id)}>
+                  {food.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
     )
   }
 
@@ -128,7 +182,7 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
           <DialogDescription>
             {cat
               ? 'Update the daily target, goal weight, and default foods.'
-              : 'The daily calorie target can be refined later with the calculator.'}
+              : 'Enter a weight to get a suggested daily target from the calculator.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -154,7 +208,10 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
                 min="0"
                 step="any"
                 value={targetKcal}
-                onChange={(event) => setTargetKcal(event.target.value)}
+                onChange={(event) => {
+                  setTargetKcal(event.target.value)
+                  setTargetTouched(true)
+                }}
                 required
               />
             </div>
@@ -173,42 +230,7 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
             </div>
           </div>
 
-          {cat ? (
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="cat-wet-food">Default wet food</Label>
-                <Select value={wetFoodId} onValueChange={setWetFoodId}>
-                  <SelectTrigger id="cat-wet-food" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NONE}>None</SelectItem>
-                    {foodOptions('WET').map((food) => (
-                      <SelectItem key={food.id} value={String(food.id)}>
-                        {food.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="cat-dry-food">Default dry food</Label>
-                <Select value={dryFoodId} onValueChange={setDryFoodId}>
-                  <SelectTrigger id="cat-dry-food" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NONE}>None</SelectItem>
-                    {foodOptions('DRY').map((food) => (
-                      <SelectItem key={food.id} value={String(food.id)}>
-                        {food.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-          ) : (
+          {cat ? null : (
             <div className="grid gap-2">
               <Label htmlFor="cat-initial-weight">Initial weight (kg)</Label>
               <Input
@@ -223,6 +245,40 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
               />
             </div>
           )}
+
+          {!cat && suggestion.data && suggestedTarget !== null ? (
+            <div className="grid gap-2 rounded-md border bg-muted/40 p-3" role="status">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium">Suggested target</span>
+                <span className="text-base font-semibold">{formatKcal(suggestedTarget)}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                RER {formatKcal(suggestion.data.rer_kcal)} × {suggestion.data.factor}{' '}
+                {suggestion.data.basis === 'GOAL_WEIGHT' ? '(weight loss)' : '(maintenance)'}, based
+                on{' '}
+                {suggestion.data.basis === 'GOAL_WEIGHT'
+                  ? `goal weight ${formatKg(suggestion.data.goal_weight_kg ?? 0)}`
+                  : `weight ${formatKg(suggestion.data.current_weight_kg ?? 0)}`}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="justify-self-start"
+                onClick={() => {
+                  setTargetKcal(String(suggestedTarget))
+                  setTargetTouched(false)
+                }}
+              >
+                Use {formatKcal(suggestedTarget)}
+              </Button>
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-2 gap-4">
+            {defaultFoodField('WET', 'cat-wet-food', 'Default wet food', wetFoodId, setWetFoodId)}
+            {defaultFoodField('DRY', 'cat-dry-food', 'Default dry food', dryFoodId, setDryFoodId)}
+          </div>
 
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
 

--- a/frontend/src/components/settings/cat-form-dialog.tsx
+++ b/frontend/src/components/settings/cat-form-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useCreateCat, useFoods, useTargetSuggestionByWeight, useUpdateCat } from '@/api/hooks'
 import type { Cat, FoodType } from '@/api/types'
@@ -61,18 +61,30 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
     setError(null)
   }, [open, cat])
 
+  // True only on the render where `open` flips to true. The reset effect above
+  // clears `initialWeight` on reopen, but effects run after render — without this
+  // guard, this render's suggestion query could still fire with the *previous*
+  // session's `initialWeight` (and, on a cache hit, synchronously return its
+  // cached suggestion), racing the reset and leaving a stale target (see U8).
+  // Self-clears every render since `prevOpenRef.current` catches up immediately.
+  const prevOpenRef = useRef(open)
+  const justOpened = open && !prevOpenRef.current
+  prevOpenRef.current = open
+
   // Onboarding calculator: once a weight is entered (create mode only), fetch the
   // RER/MER suggestion from the entered weight and optional goal weight.
-  const weightForSuggestion = cat ? null : parsePositiveNumber(initialWeight)
+  const weightForSuggestion = cat || justOpened ? null : parsePositiveNumber(initialWeight)
   const goalForSuggestion = goalWeight.trim() === '' ? null : parsePositiveNumber(goalWeight)
   const suggestion = useTargetSuggestionByWeight(weightForSuggestion, goalForSuggestion, open && !cat)
   const suggestedTarget = suggestion.data ? Math.round(suggestion.data.suggested_target_kcal) : null
 
   // Prefill the target from the suggestion while the user hasn't typed their own —
-  // keeps it in sync as they adjust the weight, but never clobbers a manual value.
+  // keeps it in sync as they adjust the weight, and clears back to empty once the
+  // weight (and so the suggestion) is removed, so a stale calculated target can
+  // never be submitted for a weight that's no longer entered.
   useEffect(() => {
-    if (cat || targetTouched || suggestedTarget === null) return
-    setTargetKcal(String(suggestedTarget))
+    if (cat || targetTouched) return
+    setTargetKcal(suggestedTarget !== null ? String(suggestedTarget) : '')
   }, [cat, targetTouched, suggestedTarget])
 
   const pending = createCat.isPending || updateCat.isPending
@@ -150,25 +162,31 @@ export function CatFormDialog({ open, onOpenChange, cat }: CatFormDialogProps) {
     const options = foodOptions(type)
     return (
       <div className="grid gap-2">
-        <Label htmlFor={id}>{label}</Label>
         {options.length === 0 ? (
-          <p id={id} className="flex min-h-9 items-center text-sm text-muted-foreground">
-            Add foods in Settings first
-          </p>
+          <>
+            {/* No htmlFor: there's no interactive control to associate with yet. */}
+            <Label>{label}</Label>
+            <p className="flex min-h-9 items-center text-sm text-muted-foreground">
+              Add foods in Settings first
+            </p>
+          </>
         ) : (
-          <Select value={value} onValueChange={onValueChange}>
-            <SelectTrigger id={id} className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NONE}>None</SelectItem>
-              {options.map((food) => (
-                <SelectItem key={food.id} value={String(food.id)}>
-                  {food.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <>
+            <Label htmlFor={id}>{label}</Label>
+            <Select value={value} onValueChange={onValueChange}>
+              <SelectTrigger id={id} className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE}>None</SelectItem>
+                {options.map((food) => (
+                  <SelectItem key={food.id} value={String(food.id)}>
+                    {food.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </>
         )}
       </div>
     )

--- a/frontend/src/components/settings/food-form-dialog.test.tsx
+++ b/frontend/src/components/settings/food-form-dialog.test.tsx
@@ -76,3 +76,14 @@ test('editing a dry food labels the toggle for the dry default', async () => {
     screen.getByRole('switch', { name: /set as default dry food for all cats/i }),
   ).toBeInTheDocument()
 })
+
+test('the default-for-all-cats toggle is hidden for an archived food', async () => {
+  installFetchMock([])
+
+  const archived: Food = { ...dry, archived_at: '2026-01-01T00:00:00Z' }
+  renderWithProviders(<FoodFormDialog open onOpenChange={vi.fn()} food={archived} />)
+
+  // Setting the default while archived would 400 in the router and roll back
+  // the whole submit, including otherwise-valid field changes — hide it instead.
+  expect(screen.queryByRole('switch', { name: /set as default/i })).not.toBeInTheDocument()
+})

--- a/frontend/src/components/settings/food-form-dialog.test.tsx
+++ b/frontend/src/components/settings/food-form-dialog.test.tsx
@@ -1,0 +1,78 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, expect, test, vi } from 'vitest'
+import type { Food, FoodMutationResult } from '@/api/types'
+import { installFetchMock } from '@/test/mock-api'
+import { renderWithProviders } from '@/test/render'
+import { FoodFormDialog } from './food-form-dialog'
+
+const dry: Food = {
+  id: 2,
+  name: 'Kibble',
+  type: 'DRY',
+  calorie_basis: 'PER_100G',
+  kcal_per_basis: 350,
+  archived_at: null,
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('creating a wet food as default for all cats sends the flag and reports the count', async () => {
+  const result: FoodMutationResult = {
+    food: {
+      id: 5,
+      name: 'House Wet',
+      type: 'WET',
+      calorie_basis: 'PER_100G',
+      kcal_per_basis: 80,
+      archived_at: null,
+    },
+    defaulted_for_cat_count: 3,
+  }
+  const calls = installFetchMock([{ method: 'POST', path: '/api/foods', status: 201, body: result }])
+
+  renderWithProviders(<FoodFormDialog open onOpenChange={vi.fn()} />)
+
+  await userEvent.type(screen.getByLabelText('Name'), 'House Wet')
+  await userEvent.type(screen.getByLabelText('kcal per 100 g'), '80')
+  await userEvent.click(screen.getByRole('switch', { name: /set as default wet food for all cats/i }))
+  await userEvent.click(screen.getByRole('button', { name: 'Add food' }))
+
+  const post = await waitFor(() => {
+    const call = calls.find((c) => c.method === 'POST')
+    expect(call).toBeDefined()
+    return call!
+  })
+  expect(post.body).toMatchObject({
+    name: 'House Wet',
+    type: 'WET',
+    set_default_for_all_cats: true,
+  })
+  expect(await screen.findByText(/set as default wet food for 3 cats/i)).toBeInTheDocument()
+})
+
+test('the default-for-all-cats toggle is hidden for treats', async () => {
+  installFetchMock([])
+
+  renderWithProviders(<FoodFormDialog open onOpenChange={vi.fn()} />)
+
+  // WET is the default type → the toggle is present.
+  expect(screen.getByRole('switch', { name: /set as default/i })).toBeInTheDocument()
+
+  await userEvent.click(screen.getByRole('combobox', { name: 'Type' }))
+  await userEvent.click(await screen.findByRole('option', { name: 'Treat' }))
+
+  expect(screen.queryByRole('switch', { name: /set as default/i })).not.toBeInTheDocument()
+})
+
+test('editing a dry food labels the toggle for the dry default', async () => {
+  installFetchMock([])
+
+  renderWithProviders(<FoodFormDialog open onOpenChange={vi.fn()} food={dry} />)
+
+  expect(
+    screen.getByRole('switch', { name: /set as default dry food for all cats/i }),
+  ).toBeInTheDocument()
+})

--- a/frontend/src/components/settings/food-form-dialog.tsx
+++ b/frontend/src/components/settings/food-form-dialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { useCreateFood, useUpdateFood } from '@/api/hooks'
-import type { CalorieBasis, Food, FoodType } from '@/api/types'
+import type { CalorieBasis, Food, FoodMutationResult, FoodType } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
 import { parsePositiveNumber } from '@/lib/format'
 
 const FOOD_TYPE_LABELS: Record<FoodType, string> = {
@@ -31,6 +32,13 @@ const FOOD_TYPE_LABELS: Record<FoodType, string> = {
 const BASIS_LABELS: Record<CalorieBasis, string> = {
   PER_100G: 'per 100 g',
   PER_PIECE: 'per piece',
+}
+
+/** Lowercase noun for the "set as default … food for all cats" toggle (never TREAT). */
+const DEFAULT_FOR_LABEL: Record<FoodType, string> = {
+  WET: 'wet',
+  DRY: 'dry',
+  TREAT: 'treat',
 }
 
 interface FoodFormDialogProps {
@@ -48,6 +56,8 @@ export function FoodFormDialog({ open, onOpenChange, food }: FoodFormDialogProps
   const [type, setType] = useState<FoodType>('WET')
   const [basis, setBasis] = useState<CalorieBasis>('PER_100G')
   const [kcal, setKcal] = useState('')
+  // Action flag, not a stored field: point every cat's default at this food on save.
+  const [setDefaultForAll, setSetDefaultForAll] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // Re-seed the form whenever the dialog opens (create: blank; edit: current values).
@@ -57,6 +67,7 @@ export function FoodFormDialog({ open, onOpenChange, food }: FoodFormDialogProps
     setType(food?.type ?? 'WET')
     setBasis(food?.calorie_basis ?? 'PER_100G')
     setKcal(food ? String(food.kcal_per_basis) : '')
+    setSetDefaultForAll(false)
     setError(null)
   }, [open, food])
 
@@ -75,20 +86,42 @@ export function FoodFormDialog({ open, onOpenChange, food }: FoodFormDialogProps
       return
     }
 
-    const onSuccess = () => {
-      toast.success(food ? `${trimmedName} updated` : `${trimmedName} added`)
+    // The type is fixed once a food exists; only WET/DRY foods can be a default.
+    const effectiveType = food?.type ?? type
+    const setDefault = effectiveType !== 'TREAT' && setDefaultForAll
+
+    const onSuccess = (result: FoodMutationResult) => {
+      const description =
+        setDefault && result.defaulted_for_cat_count > 0
+          ? `Set as default ${DEFAULT_FOR_LABEL[effectiveType]} food for ${result.defaulted_for_cat_count} ${result.defaulted_for_cat_count === 1 ? 'cat' : 'cats'}`
+          : undefined
+      toast.success(food ? `${trimmedName} updated` : `${trimmedName} added`, { description })
       onOpenChange(false)
     }
     const onError = (err: Error) => setError(err.message)
 
     if (food) {
       updateFood.mutate(
-        { id: food.id, body: { name: trimmedName, calorie_basis: basis, kcal_per_basis: kcalValue } },
+        {
+          id: food.id,
+          body: {
+            name: trimmedName,
+            calorie_basis: basis,
+            kcal_per_basis: kcalValue,
+            set_default_for_all_cats: setDefault,
+          },
+        },
         { onSuccess, onError },
       )
     } else {
       createFood.mutate(
-        { name: trimmedName, type, calorie_basis: basis, kcal_per_basis: kcalValue },
+        {
+          name: trimmedName,
+          type,
+          calorie_basis: basis,
+          kcal_per_basis: kcalValue,
+          set_default_for_all_cats: setDefault,
+        },
         { onSuccess, onError },
       )
     }
@@ -173,6 +206,19 @@ export function FoodFormDialog({ open, onOpenChange, food }: FoodFormDialogProps
               required
             />
           </div>
+
+          {(food?.type ?? type) !== 'TREAT' ? (
+            <div className="flex items-center gap-2">
+              <Switch
+                id="food-set-default"
+                checked={setDefaultForAll}
+                onCheckedChange={setSetDefaultForAll}
+              />
+              <Label htmlFor="food-set-default" className="text-sm font-normal">
+                Set as default {DEFAULT_FOR_LABEL[food?.type ?? type]} food for all cats
+              </Label>
+            </div>
+          ) : null}
 
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
 

--- a/frontend/src/components/settings/food-form-dialog.tsx
+++ b/frontend/src/components/settings/food-form-dialog.tsx
@@ -207,7 +207,7 @@ export function FoodFormDialog({ open, onOpenChange, food }: FoodFormDialogProps
             />
           </div>
 
-          {(food?.type ?? type) !== 'TREAT' ? (
+          {(food?.type ?? type) !== 'TREAT' && food?.archived_at == null ? (
             <div className="flex items-center gap-2">
               <Switch
                 id="food-set-default"

--- a/frontend/src/components/settings/household-card.tsx
+++ b/frontend/src/components/settings/household-card.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { ThemeToggle } from './theme-toggle'
 
 export function HouseholdCard() {
   const settings = useSettings()
@@ -86,6 +87,9 @@ export function HouseholdCard() {
           each cat&apos;s daily target across the meals per day.
         </CardDescription>
       </CardHeader>
+      <CardContent>
+        <ThemeToggle />
+      </CardContent>
       {settings.isPending ? (
         <CardContent>
           <p className="py-4 text-sm text-muted-foreground">Loading settings…</p>

--- a/frontend/src/components/settings/theme-toggle.test.tsx
+++ b/frontend/src/components/settings/theme-toggle.test.tsx
@@ -27,3 +27,30 @@ test('defaults to system and applies the chosen theme on click', async () => {
   expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
   expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
 })
+
+test('only the checked option is tabbable, and arrow keys move focus and selection', async () => {
+  render(<ThemeToggle />)
+
+  const system = screen.getByRole('radio', { name: /system/i })
+  const light = screen.getByRole('radio', { name: /light/i })
+  const dark = screen.getByRole('radio', { name: /dark/i })
+
+  expect(system).toHaveAttribute('tabindex', '0')
+  expect(light).toHaveAttribute('tabindex', '-1')
+  expect(dark).toHaveAttribute('tabindex', '-1')
+
+  system.focus()
+  await userEvent.keyboard('{ArrowRight}')
+  expect(light).toHaveFocus()
+  expect(light).toHaveAttribute('aria-checked', 'true')
+  expect(light).toHaveAttribute('tabindex', '0')
+  expect(system).toHaveAttribute('tabindex', '-1')
+
+  await userEvent.keyboard('{ArrowLeft}')
+  expect(system).toHaveFocus()
+  expect(system).toHaveAttribute('aria-checked', 'true')
+
+  await userEvent.keyboard('{ArrowLeft}')
+  expect(dark).toHaveFocus()
+  expect(dark).toHaveAttribute('aria-checked', 'true')
+})

--- a/frontend/src/components/settings/theme-toggle.test.tsx
+++ b/frontend/src/components/settings/theme-toggle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, expect, test } from 'vitest'
+import { THEME_STORAGE_KEY } from '@/lib/theme'
+import { ThemeToggle } from './theme-toggle'
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme')
+})
+
+test('defaults to system and applies the chosen theme on click', async () => {
+  render(<ThemeToggle />)
+
+  expect(screen.getByRole('radio', { name: /system/i })).toHaveAttribute('aria-checked', 'true')
+  expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+
+  await userEvent.click(screen.getByRole('radio', { name: /dark/i }))
+  expect(screen.getByRole('radio', { name: /dark/i })).toHaveAttribute('aria-checked', 'true')
+  expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+
+  await userEvent.click(screen.getByRole('radio', { name: /light/i }))
+  expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+
+  await userEvent.click(screen.getByRole('radio', { name: /system/i }))
+  expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
+})

--- a/frontend/src/components/settings/theme-toggle.tsx
+++ b/frontend/src/components/settings/theme-toggle.tsx
@@ -1,10 +1,10 @@
-import { Monitor, Moon, Sun } from 'lucide-react'
-import type { ComponentType } from 'react'
+import { Monitor, Moon, Sun, type LucideIcon } from 'lucide-react'
+import { useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { type ThemeMode, useThemeMode } from '@/lib/theme'
 
-const OPTIONS: { mode: ThemeMode; label: string; Icon: ComponentType }[] = [
+const OPTIONS: { mode: ThemeMode; label: string; Icon: LucideIcon }[] = [
   { mode: 'system', label: 'System', Icon: Monitor },
   { mode: 'light', label: 'Light', Icon: Sun },
   { mode: 'dark', label: 'Dark', Icon: Moon },
@@ -14,27 +14,62 @@ const OPTIONS: { mode: ThemeMode; label: string; Icon: ComponentType }[] = [
  * Compact three-way light/dark/system control. Applies immediately (persisted to
  * localStorage), independent of the household-settings save. Lives in Settings so
  * it stays out of the mobile dashboard's space.
+ *
+ * Follows the ARIA radiogroup keyboard pattern: only the checked option is a tab
+ * stop (roving tabindex), and arrow keys move focus and selection together
+ * between options, wrapping at the ends.
  */
 export function ThemeToggle() {
   const { mode, setMode } = useThemeMode()
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  function moveTo(index: number) {
+    const wrapped = (index + OPTIONS.length) % OPTIONS.length
+    const option = OPTIONS[wrapped]
+    if (!option) return
+    setMode(option.mode)
+    buttonRefs.current[wrapped]?.focus()
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, index: number) {
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault()
+        moveTo(index + 1)
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault()
+        moveTo(index - 1)
+        break
+      default:
+        break
+    }
+  }
+
   return (
     <div className="grid gap-2">
-      <Label htmlFor="theme-toggle">Theme</Label>
+      <Label id="theme-toggle-label">Theme</Label>
       <div
-        id="theme-toggle"
         role="radiogroup"
-        aria-label="Theme"
+        aria-labelledby="theme-toggle-label"
         className="inline-flex w-fit gap-0.5 rounded-lg border p-0.5"
       >
-        {OPTIONS.map(({ mode: optionMode, label, Icon }) => (
+        {OPTIONS.map(({ mode: optionMode, label, Icon }, index) => (
           <Button
             key={optionMode}
+            ref={(element) => {
+              buttonRefs.current[index] = element
+            }}
             type="button"
             role="radio"
             aria-checked={mode === optionMode}
+            tabIndex={mode === optionMode ? 0 : -1}
             variant={mode === optionMode ? 'secondary' : 'ghost'}
             size="sm"
             onClick={() => setMode(optionMode)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
           >
             <Icon data-icon="inline-start" aria-hidden />
             {label}

--- a/frontend/src/components/settings/theme-toggle.tsx
+++ b/frontend/src/components/settings/theme-toggle.tsx
@@ -1,0 +1,46 @@
+import { Monitor, Moon, Sun } from 'lucide-react'
+import type { ComponentType } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { type ThemeMode, useThemeMode } from '@/lib/theme'
+
+const OPTIONS: { mode: ThemeMode; label: string; Icon: ComponentType }[] = [
+  { mode: 'system', label: 'System', Icon: Monitor },
+  { mode: 'light', label: 'Light', Icon: Sun },
+  { mode: 'dark', label: 'Dark', Icon: Moon },
+]
+
+/**
+ * Compact three-way light/dark/system control. Applies immediately (persisted to
+ * localStorage), independent of the household-settings save. Lives in Settings so
+ * it stays out of the mobile dashboard's space.
+ */
+export function ThemeToggle() {
+  const { mode, setMode } = useThemeMode()
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="theme-toggle">Theme</Label>
+      <div
+        id="theme-toggle"
+        role="radiogroup"
+        aria-label="Theme"
+        className="inline-flex w-fit gap-0.5 rounded-lg border p-0.5"
+      >
+        {OPTIONS.map(({ mode: optionMode, label, Icon }) => (
+          <Button
+            key={optionMode}
+            type="button"
+            role="radio"
+            aria-checked={mode === optionMode}
+            variant={mode === optionMode ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setMode(optionMode)}
+          >
+            <Icon data-icon="inline-start" aria-hidden />
+            {label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,13 +1,15 @@
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+import { useThemeMode } from "@/lib/theme"
 
-// Diverges from stock shadcn: no `next-themes` (spec locks theming to the
-// system preference). Sonner's `theme="system"` already follows
-// `prefers-color-scheme` on its own.
+// Diverges from stock shadcn: no `next-themes`. The three-way theme toggle
+// (light/dark/system) lives in `lib/theme.ts`; sonner accepts the same mode
+// values, so the toaster follows the chosen theme (and the OS in system mode).
 const Toaster = ({ ...props }: ToasterProps) => {
+  const { mode } = useThemeMode()
   return (
     <Sonner
-      theme="system"
+      theme={mode}
       className="toaster group"
       icons={{
         success: (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,13 +4,25 @@
 @import "@fontsource-variable/geist";
 
 /*
- * Dark mode strategy: system `prefers-color-scheme` only (spec: no toggle, no
- * `.dark` class switching). This overrides Tailwind's default `dark:` variant
- * to a media query, and the theme variables below switch under the same media
- * query on :root — so shadcn components (CSS-variable driven) and any `dark:`
- * utilities both follow the OS preference automatically.
+ * Dark mode strategy: class-strategy with a system fallback (three-way toggle —
+ * light / dark / system; see `lib/theme.ts`). The dark theme variables below live
+ * under BOTH `[data-theme="dark"]` (explicit choice) and
+ * `@media (prefers-color-scheme: dark)` scoped to `:root:not([data-theme])`
+ * (system default, no attribute set); light lives on `:root, [data-theme="light"]`.
+ * This `dark:` variant mirrors that so any `dark:` utility follows the same rules:
+ * it matches an explicit dark attribute, or the OS preference when no attribute
+ * is set. shadcn components are CSS-variable driven, so they flip via the vars.
  */
-@custom-variant dark (@media (prefers-color-scheme: dark));
+@custom-variant dark {
+  &:where([data-theme="dark"], [data-theme="dark"] *) {
+    @slot;
+  }
+  @media (prefers-color-scheme: dark) {
+    &:where(:root:not([data-theme]), :root:not([data-theme]) *) {
+      @slot;
+    }
+  }
+}
 
 @theme inline {
     --font-heading: var(--font-sans);
@@ -55,7 +67,8 @@
     --radius-4xl: calc(var(--radius) * 2.6);
 }
 
-:root {
+:root,
+[data-theme='light'] {
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);
@@ -98,8 +111,51 @@
     --sidebar-ring: oklch(0.708 0 0);
 }
 
+/*
+ * Dark theme tokens, applied by two selectors so they cover both ways of being
+ * dark: `[data-theme='dark']` for the explicit toggle choice, and
+ * `:root:not([data-theme])` under the dark media query for the system default
+ * (no attribute set). The value list is intentionally repeated across the two
+ * rules — plain CSS can't share a declaration block between a bare selector and
+ * one nested in `@media`; keep the two lists in sync.
+ */
+[data-theme='dark'] {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+    /* Chart series hues — dark mode: same five hues re-stepped for the dark surface. */
+    --chart-1: #3987e5;
+    --chart-2: #199e70;
+    --chart-3: #d95926;
+    --chart-4: #008300;
+    --chart-5: #9085e9;
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.556 0 0);
+}
+
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme]) {
         --background: oklch(0.145 0 0);
         --foreground: oklch(0.985 0 0);
         --card: oklch(0.205 0 0);

--- a/frontend/src/lib/theme.test.ts
+++ b/frontend/src/lib/theme.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import {
+  applyThemeMode,
+  getStoredThemeMode,
+  isThemeMode,
+  resolveTheme,
+  setThemeMode,
+  subscribeToSystemTheme,
+  systemPrefersDark,
+  THEME_STORAGE_KEY,
+} from './theme'
+
+let mediaMatches = false
+const changeListeners = new Set<() => void>()
+
+beforeEach(() => {
+  mediaMatches = false
+  changeListeners.clear()
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme')
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    get matches() {
+      return mediaMatches
+    },
+    media: query,
+    onchange: null,
+    addEventListener: (_type: string, cb: () => void) => changeListeners.add(cb),
+    removeEventListener: (_type: string, cb: () => void) => changeListeners.delete(cb),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('isThemeMode narrows only the three valid modes', () => {
+  expect(isThemeMode('light')).toBe(true)
+  expect(isThemeMode('dark')).toBe(true)
+  expect(isThemeMode('system')).toBe(true)
+  expect(isThemeMode('sepia')).toBe(false)
+  expect(isThemeMode(null)).toBe(false)
+})
+
+test('getStoredThemeMode defaults to system when absent or invalid', () => {
+  expect(getStoredThemeMode()).toBe('system')
+  localStorage.setItem(THEME_STORAGE_KEY, 'nonsense')
+  expect(getStoredThemeMode()).toBe('system')
+  localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+  expect(getStoredThemeMode()).toBe('dark')
+})
+
+test('applyThemeMode sets data-theme for light/dark and removes it for system', () => {
+  applyThemeMode('dark')
+  expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  applyThemeMode('light')
+  expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+  applyThemeMode('system')
+  expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+})
+
+test('setThemeMode persists and applies across a light -> dark -> system transition', () => {
+  setThemeMode('light')
+  expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+  expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+
+  setThemeMode('dark')
+  expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+  expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+
+  setThemeMode('system')
+  expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
+  expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+})
+
+test('resolveTheme follows the OS preference only in system mode', () => {
+  mediaMatches = true
+  expect(systemPrefersDark()).toBe(true)
+  expect(resolveTheme('system')).toBe('dark')
+  expect(resolveTheme('light')).toBe('light')
+  mediaMatches = false
+  expect(resolveTheme('system')).toBe('light')
+  expect(resolveTheme('dark')).toBe('dark')
+})
+
+test('subscribeToSystemTheme fires on matchMedia change and stops after unsubscribe', () => {
+  const listener = vi.fn()
+  const unsubscribe = subscribeToSystemTheme(listener)
+
+  changeListeners.forEach((cb) => cb())
+  expect(listener).toHaveBeenCalledTimes(1)
+
+  unsubscribe()
+  changeListeners.forEach((cb) => cb())
+  expect(listener).toHaveBeenCalledTimes(1)
+})

--- a/frontend/src/lib/theme.test.tsx
+++ b/frontend/src/lib/theme.test.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import {
   applyThemeMode,
@@ -8,6 +10,7 @@ import {
   subscribeToSystemTheme,
   systemPrefersDark,
   THEME_STORAGE_KEY,
+  useThemeMode,
 } from './theme'
 
 let mediaMatches = false
@@ -95,4 +98,41 @@ test('subscribeToSystemTheme fires on matchMedia change and stops after unsubscr
   unsubscribe()
   changeListeners.forEach((cb) => cb())
   expect(listener).toHaveBeenCalledTimes(1)
+})
+
+function ModeReadout({ testId }: { testId: string }) {
+  const { mode } = useThemeMode()
+  return <span data-testid={testId}>{mode}</span>
+}
+
+function ModeToggleButton() {
+  const { setMode } = useThemeMode()
+  return (
+    <button type="button" onClick={() => setMode('dark')}>
+      Set dark
+    </button>
+  )
+}
+
+// Regression test for the desync bug: separate useThemeMode instances (e.g. the
+// Settings toggle and the Toaster) used to each hold independent useState, so a
+// change from one left the others stale until a remount. All instances now read
+// one shared store via useSyncExternalStore.
+test('a mode change from one useThemeMode consumer is immediately visible to another', async () => {
+  const user = userEvent.setup()
+  render(
+    <>
+      <ModeToggleButton />
+      <ModeReadout testId="a" />
+      <ModeReadout testId="b" />
+    </>,
+  )
+
+  expect(screen.getByTestId('a')).toHaveTextContent('system')
+  expect(screen.getByTestId('b')).toHaveTextContent('system')
+
+  await user.click(screen.getByRole('button', { name: 'Set dark' }))
+
+  expect(screen.getByTestId('a')).toHaveTextContent('dark')
+  expect(screen.getByTestId('b')).toHaveTextContent('dark')
 })

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,110 @@
+/**
+ * Theme mode: `light` | `dark` | `system`, persisted in localStorage and applied
+ * to `<html>` via a `data-theme` attribute.
+ *
+ * The CSS (see `index.css`) is class-strategy with a system fallback: dark tokens
+ * live under both `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)`
+ * scoped to `:root:not([data-theme])`. So `system` mode means "no attribute" and
+ * the media query drives the flip automatically — no JS repaint needed. The
+ * `matchMedia` subscription here exists only to keep React state (`resolvedTheme`)
+ * in sync when the OS preference changes while in system mode.
+ *
+ * `index.html` runs a tiny inline copy of {@link applyThemeMode}'s logic in
+ * `<head>` before paint so the stored theme lands without a flash.
+ */
+import { useCallback, useEffect, useState } from 'react'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type ResolvedTheme = 'light' | 'dark'
+
+/** localStorage key; kept in sync with the inline pre-paint script in index.html. */
+export const THEME_STORAGE_KEY = 'cat-tracker-theme'
+
+export function isThemeMode(value: unknown): value is ThemeMode {
+  return value === 'light' || value === 'dark' || value === 'system'
+}
+
+/** The persisted mode; `system` when absent or invalid (the default behavior). */
+export function getStoredThemeMode(): ThemeMode {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY)
+    return isThemeMode(stored) ? stored : 'system'
+  } catch {
+    return 'system'
+  }
+}
+
+/** Apply a mode to `<html>`: set `data-theme` for light/dark, remove it for system. */
+export function applyThemeMode(mode: ThemeMode): void {
+  const root = document.documentElement
+  if (mode === 'system') {
+    root.removeAttribute('data-theme')
+  } else {
+    root.setAttribute('data-theme', mode)
+  }
+}
+
+/** Persist a mode to localStorage (tolerating storage being unavailable). */
+export function persistThemeMode(mode: ThemeMode): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, mode)
+  } catch {
+    // Private-mode / disabled storage: the in-memory state still drives this session.
+  }
+}
+
+/** Persist and apply a mode in one step (imperative callers and tests). */
+export function setThemeMode(mode: ThemeMode): void {
+  persistThemeMode(mode)
+  applyThemeMode(mode)
+}
+
+export function systemPrefersDark(): boolean {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+export function resolveTheme(mode: ThemeMode): ResolvedTheme {
+  if (mode === 'system') return systemPrefersDark() ? 'dark' : 'light'
+  return mode
+}
+
+/**
+ * Subscribe to OS light/dark changes. Returns an unsubscribe function. Used only
+ * while in system mode, where the CSS media query already handles the visual flip.
+ */
+export function subscribeToSystemTheme(listener: () => void): () => void {
+  const mql = window.matchMedia('(prefers-color-scheme: dark)')
+  mql.addEventListener('change', listener)
+  return () => mql.removeEventListener('change', listener)
+}
+
+/**
+ * React binding for the theme: current `mode`, the `resolvedTheme` it renders as,
+ * and a `setMode` that persists the choice. Applies the mode to `<html>` on mount
+ * and on change; while in system mode, re-renders when the OS preference flips.
+ */
+export function useThemeMode(): {
+  mode: ThemeMode
+  resolvedTheme: ResolvedTheme
+  setMode: (mode: ThemeMode) => void
+} {
+  const [mode, setModeState] = useState<ThemeMode>(getStoredThemeMode)
+  const [systemDark, setSystemDark] = useState<boolean>(systemPrefersDark)
+
+  useEffect(() => {
+    applyThemeMode(mode)
+  }, [mode])
+
+  useEffect(() => {
+    if (mode !== 'system') return undefined
+    return subscribeToSystemTheme(() => setSystemDark(systemPrefersDark()))
+  }, [mode])
+
+  const setMode = useCallback((next: ThemeMode) => {
+    persistThemeMode(next)
+    setModeState(next)
+  }, [])
+
+  const resolvedTheme: ResolvedTheme = mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
+  return { mode, resolvedTheme, setMode }
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -5,14 +5,18 @@
  * The CSS (see `index.css`) is class-strategy with a system fallback: dark tokens
  * live under both `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)`
  * scoped to `:root:not([data-theme])`. So `system` mode means "no attribute" and
- * the media query drives the flip automatically — no JS repaint needed. The
- * `matchMedia` subscription here exists only to keep React state (`resolvedTheme`)
- * in sync when the OS preference changes while in system mode.
+ * the media query drives the flip automatically — no JS repaint needed.
+ *
+ * `mode`/`systemDark` live in one module-level store (below `useThemeMode`)
+ * rather than per-hook `useState`, so every consumer (the Settings toggle, the
+ * Toaster, ...) re-renders together on a change instead of drifting out of sync
+ * until a remount. `useSyncExternalStore` is React's binding for exactly this
+ * shape of external mutable state.
  *
  * `index.html` runs a tiny inline copy of {@link applyThemeMode}'s logic in
  * `<head>` before paint so the stored theme lands without a flash.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 export type ResolvedTheme = 'light' | 'dark'
@@ -53,12 +57,6 @@ export function persistThemeMode(mode: ThemeMode): void {
   }
 }
 
-/** Persist and apply a mode in one step (imperative callers and tests). */
-export function setThemeMode(mode: ThemeMode): void {
-  persistThemeMode(mode)
-  applyThemeMode(mode)
-}
-
 export function systemPrefersDark(): boolean {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
 }
@@ -78,33 +76,76 @@ export function subscribeToSystemTheme(listener: () => void): () => void {
   return () => mql.removeEventListener('change', listener)
 }
 
+// --- Shared store ------------------------------------------------------------
+//
+// One `mode`/`systemDark` pair for the whole app. `subscribe` lazily (re)syncs
+// from localStorage and starts tracking `matchMedia` the moment the *first*
+// consumer mounts, and tears the `matchMedia` listener down once the *last* one
+// unmounts — so `systemDark` is never stale (fixes the "switch back to system
+// mode shows the wrong theme until the OS preference changes again" case: it's
+// now tracked unconditionally, not just while `mode === 'system'`), and nothing
+// leaks a `matchMedia` subscription for the lifetime of the page when no
+// consumer is mounted.
+type Listener = () => void
+
+let mode: ThemeMode = getStoredThemeMode()
+let systemDark = false
+let unsubscribeFromSystemTheme: (() => void) | null = null
+const listeners = new Set<Listener>()
+
+function notify(): void {
+  listeners.forEach((listener) => listener())
+}
+
+function subscribe(listener: Listener): () => void {
+  if (listeners.size === 0) {
+    mode = getStoredThemeMode()
+    systemDark = systemPrefersDark()
+    unsubscribeFromSystemTheme = subscribeToSystemTheme(() => {
+      systemDark = systemPrefersDark()
+      notify()
+    })
+  }
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0 && unsubscribeFromSystemTheme) {
+      unsubscribeFromSystemTheme()
+      unsubscribeFromSystemTheme = null
+    }
+  }
+}
+
+function getModeSnapshot(): ThemeMode {
+  return mode
+}
+
+function getSystemDarkSnapshot(): boolean {
+  return systemDark
+}
+
+/** Persist, apply, and broadcast a mode to every `useThemeMode` consumer. */
+export function setThemeMode(next: ThemeMode): void {
+  persistThemeMode(next)
+  applyThemeMode(next)
+  mode = next
+  notify()
+}
+
 /**
  * React binding for the theme: current `mode`, the `resolvedTheme` it renders as,
- * and a `setMode` that persists the choice. Applies the mode to `<html>` on mount
- * and on change; while in system mode, re-renders when the OS preference flips.
+ * and a `setMode` that persists the choice. Every instance reads the same shared
+ * store, so a change made through one component (e.g. the Settings toggle) is
+ * immediately visible to every other mounted consumer (e.g. the Toaster).
  */
 export function useThemeMode(): {
   mode: ThemeMode
   resolvedTheme: ResolvedTheme
   setMode: (mode: ThemeMode) => void
 } {
-  const [mode, setModeState] = useState<ThemeMode>(getStoredThemeMode)
-  const [systemDark, setSystemDark] = useState<boolean>(systemPrefersDark)
-
-  useEffect(() => {
-    applyThemeMode(mode)
-  }, [mode])
-
-  useEffect(() => {
-    if (mode !== 'system') return undefined
-    return subscribeToSystemTheme(() => setSystemDark(systemPrefersDark()))
-  }, [mode])
-
-  const setMode = useCallback((next: ThemeMode) => {
-    persistThemeMode(next)
-    setModeState(next)
-  }, [])
-
-  const resolvedTheme: ResolvedTheme = mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
-  return { mode, resolvedTheme, setMode }
+  const currentMode = useSyncExternalStore(subscribe, getModeSnapshot)
+  const currentSystemDark = useSyncExternalStore(subscribe, getSystemDarkSnapshot)
+  const resolvedTheme: ResolvedTheme =
+    currentMode === 'system' ? (currentSystemDark ? 'dark' : 'light') : currentMode
+  return { mode: currentMode, resolvedTheme, setMode: setThemeMode }
 }


### PR DESCRIPTION
A user-requested UX batch: onboarding improvements, a theme toggle, and a bulk-default affordance. Backend + frontend + docs, with tests both sides.

## 1. RER calculator at cat creation
`GET /api/target-suggestion` now works **before a cat exists**: it accepts an explicit `weight_kg` (plus optional `goal_weight_kg`) as an alternative to `cat_id`, using the same RER/MER math. Exactly one mode is required — neither, both, or `goal_weight_kg` alongside `cat_id` is a `422`; `cat_id` is nullable in the response. In the add-cat dialog, entering a weight fetches the suggestion, shows the RER breakdown inline, prefills the daily target (a manual edit always wins), and offers a one-tap **Use** button. No weight entered → the plain manual target field, unchanged.

## 2. Default foods at cat onboarding
The optional default wet/dry food selects now appear in the **create** dialog too (same non-archived, type-matched filtering as edit mode). An empty library shows an "Add foods in Settings first" hint and never blocks creating the cat. `CatCreate` already accepted the default IDs with the right validation; added a test to pin it.

## 3. Theme toggle — light / dark / system  ⚠️ DELIBERATE DECISION REVERSAL
**This reverses the previously locked "media-only, no toggle" theming decision.** The product owner changed it after living with the app, so reviewers checking against the old spec text will (correctly) notice the conflict — it is intended, and the docs are amended in this PR so future agents don't "fix" the toggle away (CLAUDE.md rule 4, ARCHITECTURE.md new Theming section, FEATURE_PARITY.md theming + Parity Chrome lines).

- `frontend/src/lib/theme.ts`: mode (`light`/`dark`/`system`) persisted in localStorage, reflected onto `<html>` as a `data-theme` attribute — removed for `system` so the `prefers-color-scheme` media query drives the flip; while in system mode `useThemeMode` subscribes to `matchMedia` to keep `resolvedTheme` current.
- `frontend/src/index.css`: class-strategy with a system fallback. Dark tokens live under **both** `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` scoped to `:root:not([data-theme])`; light under `:root, [data-theme="light"]`. The Tailwind `dark:` variant is redefined to match the same two conditions.
- Inline `<head>` script in `index.html` applies the stored mode pre-paint (no flash).
- Compact three-way control in the Settings household card (kept off the mobile dashboard).
- Charts flip via their existing `color: var(--chart-N)` ChartConfigs (the `theme` key is deliberately not used). The sonner toaster follows the chosen mode. PWA `theme-color` metas still track the OS only — an accepted limitation, noted in `index.html` and FEATURE_PARITY.

## 4. Set-default-for-all-cats on food create/edit
`FoodCreate`/`FoodUpdate` accept an optional `set_default_for_all_cats`; when set on a WET/DRY food it points every cat's matching default at it in the same transaction. TREAT or archived food is rejected with `400` (consistent with the existing per-cat default validation — documented). `POST`/`PATCH /foods` now return `FoodMutationResult` (`{ food, defaulted_for_cat_count }`). The form gets an optional toggle (hidden for treats); success toast reports how many cats were updated. Existing meal snapshots are untouched — pinned by a test.

## Verification
- Backend: `ruff` / `ruff format` / `mypy app tests` clean; **pytest 110 passed** (was 97).
- Frontend: `tsc -b` clean; `oxlint` 0 errors (pre-existing pedantic warnings only); **vitest 86 passed** (was 71); `vite build` green.
- `pnpm gen:api` regenerated and committed; idempotent on re-run.
- Docker image builds green.

## Notes / judgment calls
- The "set as default for all cats" control uses the repo's existing `Switch` idiom (as with "Show archived foods" / "Portion suggestions") rather than adding a new Checkbox component; the spec said "checkbox" but Switch is the established form-toggle pattern here.
- TREAT and archived-food rejection both return `400` (not `422`) to match the existing default-food validation convention, rather than the `422` the brief floated for TREAT.
- Food create/update responses changed shape to `FoodMutationResult`; the `create_food` test helper unwraps `["food"]` so downstream tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
